### PR TITLE
Fixes specifying VAULT_TOKEN and VAULT_URL on the command line

### DIFF
--- a/vault-recursive-delete.rb
+++ b/vault-recursive-delete.rb
@@ -13,11 +13,11 @@ options = {}
 parser = OptionParser.new do |opts|
   opts.banner = "Recursive delete for paths in vault.\n\nUsage: #{SCRIPT_NAME} [options]"
 
-  opts.on('-a[VAULT_ADDR]', '--vault-address=[VAULT_ADDR]', 'URL used to access the Vault server. Defaults to the VAULT_ADDR environment variable') do |v|
+  opts.on('-aVAULT_ADDR', '--vault-address=VAULT_ADDR', 'Optional: URL used to access the Vault server. Defaults to the VAULT_ADDR environment variable') do |v|
     options[:vault_addr] = v
   end
 
-  opts.on('-t[VAULT_TOKEN]', '--vault-token=[VAULT_TOKEN]', 'A vault token. Defaults to VAULT_TOKEN environment variable, or reads ~/.vault-token') do |v|
+  opts.on('-tVAULT_TOKEN', '--vault-token=VAULT_TOKEN', 'Optional: A vault token. Defaults to VAULT_TOKEN environment variable, or reads ~/.vault-token') do |v|
     options[:vault_token] = v
   end
 


### PR DESCRIPTION
The command line switches for the vault token and the vault url were not
respecting the values being entered.

When I wrote this code I couldn't find very many examples for properly
specifying an optional argument with the optionparser ruby library, and
it seems to be that the one I ended up using as a template was written
incorrectly. This patch uses the proper syntax, and now those switches
work.

-----

Fixes #2 